### PR TITLE
Expose Bindable methods

### DIFF
--- a/Sources/Bindable.swift
+++ b/Sources/Bindable.swift
@@ -35,15 +35,15 @@ extension Bindable where Self: NSObject {
         }
     }
     
-    func getBinderValue() -> BindingType? {
+    public func getBinderValue() -> BindingType? {
         return binder.value
     }
     
-    func setBinderValue(with value: BindingType?) {
+    public func setBinderValue(with value: BindingType?) {
         binder.value = value
     }
     
-    func register(for observable: Observable<BindingType>) {
+    public func register(for observable: Observable<BindingType>) {
         binder = observable
     }
     
@@ -55,7 +55,7 @@ extension Bindable where Self: NSObject {
 
     public func bind(with observable: Observable<BindingType>) {
         if let _self = self as? UIControl {
-            _self.addTarget(Selector, action: Selector{ self.valueChanged() }, for: [.editingChanged, .valueChanged])
+            _self.addTarget(Selector, action: Selector{ [weak self] in self?.valueChanged() }, for: [.editingChanged, .valueChanged])
         }
         self.binder = observable
         if let val = observable.value {

--- a/Sources/UIControls+Bindable.swift
+++ b/Sources/UIControls+Bindable.swift
@@ -81,39 +81,12 @@ public class BindableTextView: UITextView, Bindable, UITextViewDelegate {
     public func bind(with observable: Observable<String>) {
         self.delegate = self
         self.register(for: observable)
-        self.observe(for: observable) { (value) in
-            self.updateValue(with: value)
+        self.observe(for: observable) { [weak self] (value) in
+            self?.updateValue(with: value)
         }
     }
     
     public func textViewDidChange(_ textView: UITextView) {
         self.valueChanged()
-    }
-}
-
-public protocol  BindableTableViewProtocol {
-    func dataSourceUpdated(value: Data)
-}
-
-open class BindableTableView: UITableView, Bindable {
-    
-    open var sourceData: Data = Data()
-    
-    open var bindableDelegate: BindableTableViewProtocol!
-    public typealias BindingType = Data
-    
-    public func observingValue() -> Data? {
-        return self.sourceData
-    }
-    
-    public func updateValue(with value: Data) {
-        bindableDelegate.dataSourceUpdated(value: value)
-    }
-    
-    public func bind(with observable: Observable<Data>) {
-        self.register(for: observable)
-        self.observe(for: observable) { (value) in
-            self.updateValue(with: value)
-        }
     }
 }


### PR DESCRIPTION
Things in this commit -

1. Expose Bindable methods to make it possible to conform to bindable from outside the Pod
2. Added weak references to closures to prevent retain cycles.
3. Remove BindableTableView because it seems to be tailored to a specifc use case which cannot be generalized.