### PR TITLE
Work around UIKit which jumped cursors to the end of text view & fields

### DIFF
--- a/SimpleTwoWayBinding.podspec
+++ b/SimpleTwoWayBinding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SimpleTwoWayBinding'
-  s.version          = '0.0.2'
+  s.version          = '0.0.3'
   s.summary          = 'Ultra light weight and simple two way binding for iOS UIControls.'
   s.description      = <<-DESC
 Ultra light weight and simple two way binding for UIControls.

--- a/Sources/UIControls+Bindable.swift
+++ b/Sources/UIControls+Bindable.swift
@@ -15,7 +15,9 @@ extension UITextField : Bindable {
     }
     
     public func updateValue(with value: String) {
-        self.text = value
+        if self.text != value {
+            self.text = value
+        }
     }
 }
 
@@ -75,7 +77,9 @@ public class BindableTextView: UITextView, Bindable, UITextViewDelegate {
     }
     
     public func updateValue(with value: String) {
-        self.text = value
+        if self.text != value {
+            self.text = value
+        }
     }
     
     public func bind(with observable: Observable<String>) {


### PR DESCRIPTION
See https://github.com/manishkkatoch/SimpleTwoWayBindingIOS/issues/15 for an explanation and a repro.

This patch simply checks that the control's text is different from the value coming in from the binding, and only sets it if they are different. My testing has shown this corrects the bug in `UITextView` and `UITextField` with double-width characters.

I bumped the version so the Podfile for our app, which is temporarily pointing at my fork, will pick up these changes.