### PR TITLE
Setting value changed to public

### DIFF
--- a/Sources/Bindable.swift
+++ b/Sources/Bindable.swift
@@ -47,7 +47,7 @@ extension Bindable where Self: NSObject {
         binder = observable
     }
     
-    func valueChanged() {
+    public func valueChanged() {
         if binder.value != self.observingValue() {
             setBinderValue(with: self.observingValue())
         }


### PR DESCRIPTION
When trying to make custom class and accessing method valueChanged, system generates an error because init() method has not been implemented for this class. The simplest solution is to put "public" in front of the function that is widely used.